### PR TITLE
Avoid type cast error on custom cemuhook port

### DIFF
--- a/scc/cemuhook_server.py
+++ b/scc/cemuhook_server.py
@@ -52,7 +52,7 @@ class CemuhookServer:
 		poller = daemon.get_poller()
 		daemon.poller.register(self.socket.fileno(), poller.POLLIN, self.on_data_recieved)
 		
-		server_port = os.getenv('SCC_SERVER_PORT') or PORT;
+		server_port = int(os.getenv('SCC_SERVER_PORT') or PORT);
 		self.socket.bind(('127.0.0.1', server_port))
 		log.info("Created CemuHookUDP Motion Provider")
 


### PR DESCRIPTION
I once contributed https://github.com/kozec/sc-controller/pull/727 and just found out that it does not work in the `python3` branch of Ryochan's fork: when the daemon is started with a custom UDP port, an error message is repeated on the command line:
```
$ SCC_SERVER_PORT=26768 ./sc-controller-v0.4.8.13-lunar-x86_64.AppImage daemon debug
...
E SCCDaemon     Failed to initialize CemuHookUDP Motion Provider: 'str' object cannot be interpreted as an integer
E SCCDaemon     Failed to initialize CemuHookUDP Motion Provider: 'str' object cannot be interpreted as an integer
E SCCDaemon     Failed to initialize CemuHookUDP Motion Provider: 'str' object cannot be interpreted as an integer
...
```

This error may be caused by the move from python2 to python3, and should be fixed by this PR.

I [read](https://github.com/Ryochan7/sc-controller/issues/107#issuecomment-1902698814) that @Ryochan7 does no longer maintain the sc-controller project, and that you may be interested in taking over the repo. Please let me know if you're not interested in accepting this PR, I will close it then.