### PR TITLE
feat: allow custom ip for cemuhook server

### DIFF
--- a/scc/actions.py
+++ b/scc/actions.py
@@ -2400,7 +2400,7 @@ class TriggerAction(Action, HapticEnabledAction):
 			raise TypeError("Invalid number of parameters")
 		self.pressed = False
 		# Having AxisAction as child of TriggerAction is special case,
-		# child action recieves trigger events instead of button presses
+		# child action receives trigger events instead of button presses
 		# and button_releases.
 		self.child_is_axis = isinstance(self.action.strip(), AxisAction)
 	

--- a/scc/cemuhook_server.c
+++ b/scc/cemuhook_server.c
@@ -172,15 +172,15 @@ static void parse_message(int fd, const char* buffer, size_t size, struct sockad
 	struct Message out;
 	int i, x;
 	if ((size < 20) || (buffer[0] != 'D') || (buffer[1]!='S') || (buffer[2] != 'U') || (buffer[3] != 'C')) {
-		WARN("Recieved invalid message: Invalid header");
+		WARN("Received invalid message: Invalid header");
 		return;
 	}
 	if (msg->protocol_version > MAX_PROTO_VERSION) {
-		WARN("Recieved invalid message: Unsupported version");
+		WARN("Received invalid message: Unsupported version");
 		return;
 	}
 	if (size < msg->packet_size + 20 - 4) {
-		WARN("Recieved invalid message: Invalid size (expected %i, got %zu)", msg->packet_size + 20 - 4, size);
+		WARN("Received invalid message: Invalid size (expected %i, got %zu)", msg->packet_size + 20 - 4, size);
 		return;
 	}
 	
@@ -256,7 +256,7 @@ static void parse_message(int fd, const char* buffer, size_t size, struct sockad
 		break;
 	}
 	default:
-		// WARN("Recieved invalid message: Unknown message type");
+		// WARN("Received invalid message: Unknown message type");
 		return;
 	}
 }

--- a/scc/cemuhook_server.py
+++ b/scc/cemuhook_server.py
@@ -72,7 +72,7 @@ class CemuhookServer:
 		if fd != self.socket.fileno(): return
 		message, (ip, port) = self.socket.recvfrom(BUFFER_SIZE)
 		buffer = create_string_buffer(BUFFER_SIZE)
-		self._lib.cemuhook_data_received(fd, ip, port, message, len(message), buffer)
+		self._lib.cemuhook_data_received(fd, ip.encode('utf-8'), port, message, len(message), buffer)
 	
 	
 	def feed(self, data):

--- a/scc/cemuhook_server.py
+++ b/scc/cemuhook_server.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 log = logging.getLogger("CemuHook")
 
 BUFFER_SIZE = 1024
+IP = '127.0.0.1'
 PORT = 26760
 
 
@@ -35,8 +36,8 @@ class CemuhookServer:
 	
 	def __init__(self, daemon):
 		self._lib = find_library('libcemuhook')
-		self._lib.cemuhook_data_recieved.argtypes = [ c_int, c_int, c_char_p, c_size_t ]
-		self._lib.cemuhook_data_recieved.restype = None
+		self._lib.cemuhook_data_received.argtypes = [ c_int, c_char_p, c_int, c_char_p, c_size_t ]
+		self._lib.cemuhook_data_received.restype = None
 		self._lib.cemuhook_feed.argtypes = [ c_int, c_int, CemuhookServer.C_DATA_T ]
 		self._lib.cemuhook_feed.restype = None
 		self._lib.cemuhook_socket_enable.argtypes = []
@@ -50,10 +51,11 @@ class CemuhookServer:
 		self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 		
 		poller = daemon.get_poller()
-		daemon.poller.register(self.socket.fileno(), poller.POLLIN, self.on_data_recieved)
+		daemon.poller.register(self.socket.fileno(), poller.POLLIN, self.on_data_received)
 		
 		server_port = os.getenv('SCC_SERVER_PORT') or PORT;
-		self.socket.bind(('127.0.0.1', server_port))
+		server_ip = os.getenv('SCC_SERVER_IP') or IP;
+		self.socket.bind((server_ip, server_port))
 		log.info("Created CemuHookUDP Motion Provider")
 
 		Thread(target=self._keepalive).start()
@@ -66,11 +68,11 @@ class CemuhookServer:
 				self.feed((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
 			sleep(1)
 	
-	def on_data_recieved(self, fd, event_type):
+	def on_data_received(self, fd, event_type):
 		if fd != self.socket.fileno(): return
 		message, (ip, port) = self.socket.recvfrom(BUFFER_SIZE)
 		buffer = create_string_buffer(BUFFER_SIZE)
-		self._lib.cemuhook_data_recieved(fd, port, message, len(message), buffer)
+		self._lib.cemuhook_data_received(fd, ip, port, message, len(message), buffer)
 	
 	
 	def feed(self, data):

--- a/scc/drivers/sc_dongle.py
+++ b/scc/drivers/sc_dongle.py
@@ -93,7 +93,7 @@ class Dongle(USBDevice):
 	def _add_controller(self, endpoint):
 		"""
 		Called when new controller is detected either by HOTPLUG message or
-		by recieving first input event.
+		by receiving first input event.
 		"""
 		ccidx = FIRST_CONTROLIDX + endpoint - FIRST_ENDPOINT
 		c = SCController(self, ccidx, endpoint)

--- a/scc/drivers/usb.py
+++ b/scc/drivers/usb.py
@@ -29,7 +29,7 @@ class USBDevice(object):
 		"""
 		Helper method for setting up input transfer.
 		
-		callback(endpoint, data) is called repeadedly with every packed recieved.
+		callback(endpoint, data) is called repeadedly with every packed received.
 		"""
 		def callback_wrapper(transfer):
 			if (transfer.getStatus() != usb1.TRANSFER_COMPLETED or
@@ -40,7 +40,7 @@ class USBDevice(object):
 			try:
 				callback(endpoint, data)
 			except Exception as e:
-				log.error("Failed to handle recieved data")
+				log.error("Failed to handle received data")
 				log.error(e)
 				log.error(traceback.format_exc())
 			finally:
@@ -87,7 +87,7 @@ class USBDevice(object):
 	def make_request(self, index, callback, data, size=64):
 		"""
 		Schedules synchronous request that requires response.
-		Request is done ASAP and provided callback is called with recieved data.
+		Request is done ASAP and provided callback is called with received data.
 		"""
 		self._rmsg.append((
 			(

--- a/scc/gui/app.py
+++ b/scc/gui/app.py
@@ -1078,7 +1078,7 @@ class App(Gtk.Application, UserDataManager, BindingEditor):
 		msg = _('There was an error with enabling emulation: <b>%s</b>') % (error,)
 		# Known errors are handled with aditional message
 		if "Device not found" in error:
-			msg += "\n" + _("Please, check if you have reciever dongle connected to USB port.")
+			msg += "\n" + _("Please, check if you have receiver dongle connected to USB port.")
 		elif "LIBUSB_ERROR_ACCESS" in error:
 			msg += "\n" + _("You don't have access to controller device.")
 			msg += "\n\n" + ( _("Consult your distribution manual, try installing Steam package or <a href='%s'>install required udev rules manually</a>.") %

--- a/scc/gui/daemon_manager.py
+++ b/scc/gui/daemon_manager.py
@@ -54,7 +54,7 @@ class DaemonManager(GObject.GObject):
 		
 		unknown-msg (message)
 			Emited when message that can't be parsed internally
-			is recieved from daemon.
+			is received from daemon.
 		
 		version (ver)
 			Emited daemon reports its version - usually only once per connection.
@@ -163,7 +163,7 @@ class DaemonManager(GObject.GObject):
 		try:
 			response = sc.read_bytes_finish(results)
 			if response == None:
-				raise Exception("No data recieved")
+				raise Exception("No data received")
 		except Exception as e:
 			# Broken sonnection, daemon was probbaly terminated
 			self._on_daemon_died()

--- a/scc/lib/eudevmonitor.py
+++ b/scc/lib/eudevmonitor.py
@@ -221,7 +221,7 @@ class Enumerator:
 
 class Monitor:
 	"""
-	Monitor object recieves device events.
+	Monitor object receives device events.
 	receive_device method blocks until next event is processed, so it can be
 	used either in dumb loop, or called when select syscall reports descriptor
 	returned by get_fd has data available.

--- a/scc/lib/xwrappers.py
+++ b/scc/lib/xwrappers.py
@@ -370,7 +370,7 @@ def get_current_window(dpy):
 def get_window_type(dpy, window):
 	"""
 	Returns _NET_WM_WINDOW_TYPE value for window specified or None if anything
-	fails while recieving it.
+	fails while receiving it.
 	"""
 	trash, prop = get_window_prop(dpy, window, "_NET_WM_WINDOW_TYPE")
 	if prop is not None and prop.value is not None:

--- a/scc/sccdaemon.py
+++ b/scc/sccdaemon.py
@@ -176,7 +176,7 @@ class SCCDaemon(Daemon):
 	
 	def add_on_rescan(self, fn):
 		"""
-		Adds function that is called when `Rescan.` message is recieved.
+		Adds function that is called when `Rescan.` message is received.
 		"""
 		if fn not in self.on_exit_cbs:
 			self.rescan_cbs.append(fn)
@@ -758,7 +758,7 @@ class SCCDaemon(Daemon):
 	
 	def _handle_message(self, client, message):
 		"""
-		Handles message recieved from client.
+		Handles message received from client.
 		"""
 		if message.startswith(b"Profile:"):
 			with self.lock:

--- a/scc/scripts.py
+++ b/scc/scripts.py
@@ -143,7 +143,7 @@ def cmd_info(argv0, argv):
 	s = connect_to_daemon()
 	if s is None: return -1
 	# Daemon already sends situable info, so this is mostly reading
-	# until "Ready." message is recieved.
+	# until "Ready." message is received.
 	global_profile = None
 	any_controller = False
 	while True:


### PR DESCRIPTION
This PR add allows to set a custom IP via the environment variable `SCC_SERVER_IP`. If set, the cemuhook server listens to this IP instead of `127.0.0.1`. This is useful if the client and controller are on different machines (as reported [here](https://github.com/git-developer/batocera-extra/issues/6#issuecomment-2075705550)).