### PR TITLE
Update GitHub Actions CI script

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: rlespinasse/github-slug-action@v4
 
       - name: Setup qemu for docker
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         if: matrix.target.platform != 'linux/amd64'
 
       - name: Setup buildx for docker

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -67,13 +67,14 @@ jobs:
         uses: AppImageCrafters/build-appimage@v1.3
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: appimages
           path: |
             ./*.AppImage
             ./*.AppImage.zsync
           if-no-files-found: error
+          merge-multiple: true
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: appimage-{{ matrix.codename }}
+          name: appimage-${{ matrix.codename }}-${{ matrix.platform }}
           path: |
             ./*.AppImage
             ./*.AppImage.zsync

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -23,7 +23,6 @@ jobs:
             arch: arm64
         codename:
           - jammy
-          - lunar
           - mantic
           - noble
 

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -69,12 +69,11 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: appimages
+          name: appimage-{{ matrix.codename }}
           path: |
             ./*.AppImage
             ./*.AppImage.zsync
           if-no-files-found: error
-          merge-multiple: true
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -90,8 +89,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: appimages
+          name: appimage-*
           path: assets
+          merge-multiple: true
       - name: Create checksum for release assets
         shell: bash
         run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,9 +1,9 @@
 name: Build and publish AppImages
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
 
 env:
   BASE_OS: ubuntu
@@ -23,6 +23,7 @@ jobs:
           - jammy
           - lunar
           - mantic
+          - noble
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: appimage-*
+          pattern: appimage-*
           path: assets
           merge-multiple: true
       - name: Create checksum for release assets

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -67,7 +67,7 @@ jobs:
         uses: AppImageCrafters/build-appimage@v1.3
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: appimages
           path: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        architecture:
+          - amd64
+          - arm64
         codename:
           - jammy
           - lunar
@@ -31,7 +31,7 @@ jobs:
 
       - name: Setup qemu for docker
         uses: docker/setup-qemu-action@v2
-        if: matrix.platform != 'linux/amd64'
+        if: matrix.architecture != 'amd64'
 
       - name: Setup buildx for docker
         uses: docker/setup-buildx-action@v3
@@ -39,7 +39,7 @@ jobs:
       - name: Compile in docker
         uses: docker/build-push-action@v5
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: linux/${{ matrix.architecture }}
           outputs: build
           build-args: |
             BASE_OS
@@ -47,7 +47,7 @@ jobs:
 
       - name: Prepare environment to build AppImage
         env:
-          TARGET_PLATFORM: ${{ matrix.platform }}
+          TARGET_PLATFORM: linux/${{ matrix.architecture }}
         shell: bash
         run: |
           set -eua
@@ -69,7 +69,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: appimage-${{ matrix.codename }}-${{ matrix.platform }}
+          name: appimage-${{ matrix.codename }}-${{ matrix.architecture }}
           path: |
             ./*.AppImage
             ./*.AppImage.zsync

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -34,10 +34,10 @@ jobs:
         if: matrix.platform != 'linux/amd64'
 
       - name: Setup buildx for docker
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Compile in docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           platforms: ${{ matrix.platform }}
           outputs: build
@@ -67,7 +67,7 @@ jobs:
         uses: AppImageCrafters/build-appimage@v1.3
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: appimages
           path: |
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: appimages
           path: assets

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,9 +16,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        architecture:
-          - amd64
-          - arm64
+        target:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
         codename:
           - jammy
           - lunar
@@ -31,7 +33,7 @@ jobs:
 
       - name: Setup qemu for docker
         uses: docker/setup-qemu-action@v2
-        if: matrix.architecture != 'amd64'
+        if: matrix.target.platform != 'linux/amd64'
 
       - name: Setup buildx for docker
         uses: docker/setup-buildx-action@v3
@@ -39,7 +41,7 @@ jobs:
       - name: Compile in docker
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/${{ matrix.architecture }}
+          platforms: ${{ matrix.target.platform }}
           outputs: build
           build-args: |
             BASE_OS
@@ -47,7 +49,7 @@ jobs:
 
       - name: Prepare environment to build AppImage
         env:
-          TARGET_PLATFORM: linux/${{ matrix.architecture }}
+          TARGET_PLATFORM: ${{ matrix.target.platform }}
         shell: bash
         run: |
           set -eua
@@ -69,7 +71,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: appimage-${{ matrix.codename }}-${{ matrix.architecture }}
+          name: appimage-${{ matrix.codename }}-${{ matrix.target.arch }}
           path: |
             ./*.AppImage
             ./*.AppImage.zsync

--- a/.github/workflows/scc-linux.yml
+++ b/.github/workflows/scc-linux.yml
@@ -11,6 +11,7 @@ on:
     - main
     - master
     - python3
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates GitHub Action components to up-to-date versions and enables support for Ubuntu 24.04 (Noble Numbat). It is triggered by creation of a GitHub release or on manual action.