### PR TITLE
Fix tray icon not showing up

### DIFF
--- a/scc/gui/statusicon.py
+++ b/scc/gui/statusicon.py
@@ -350,8 +350,8 @@ class StatusIconProxy(StatusIcon):
 			for StatusIconBackend in status_icon_backends:
 				try:
 					self._status_fb = StatusIconBackend(*self._arguments[0], **self._arguments[1])
-					self._status_fb.connect(b"clicked",        self._on_click)
-					self._status_fb.connect(b"notify::active", self._on_notify_active_fb)
+					self._status_fb.connect("clicked",        self._on_click)
+					self._status_fb.connect("notify::active", self._on_notify_active_fb)
 					self._on_notify_active_fb()
 					
 					log.warning("StatusIcon: Using backend %s (fallback)" % StatusIconBackend.__name__)


### PR DESCRIPTION
There is an issue with  tray icon not showing up on wayland and x on gnome (for me - and some others https://github.com/Ryochan7/sc-controller/issues/106 ?).  This is the output of the scc gui

```❯ scc gui
/usr/lib/python3.12/site-packages/scc/gui/statusicon.py:267: PyGIWarning: AppIndicator3 was imported without specifying a version first. Use gi.require_version('AppIndicator3', '0.1') before import to ensure that the right version gets loaded.
  from gi.repository import AppIndicator3 as appindicator
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/scc/gui/statusicon.py", line 315, in __init__
    self._status_gtk = StatusIconGTK3(*args, **kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/scc/gui/statusicon.py", line 209, in __init__
    raise NotImplementedError
NotImplementedError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/scc/gui/app.py", line 1364, in do_startup
    self.setup_statusicon()
  File "/usr/lib/python3.12/site-packages/scc/gui/app.py", line 279, in setup_statusicon
    self.statusicon = get_status_icon(self.imagepath, menu)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/scc/gui/statusicon.py", line 422, in get_status_icon
    return StatusIconProxy(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/scc/gui/statusicon.py", line 323, in __init__
    self._load_fallback()
  File "/usr/lib/python3.12/site-packages/scc/gui/statusicon.py", line 354, in _load_fallback
    self._status_fb.connect(b"clicked", self._on_click)
TypeError: GObject.connect() argument 1 must be str, not bytes
```

I don't know python besides some basic stuff but this change fixes the issue for me. Please check if it's correct.

Good luck with this fork!