### PR TITLE
Fix crash on Python 3.11.2 due to wrong quoting

### DIFF
--- a/scc/gui/controller_image.py
+++ b/scc/gui/controller_image.py
@@ -93,7 +93,7 @@ class ControllerImage(SVGWidget):
 		"""
 		self.backup = backup
 		self.current = self._ensure_config(config or {}, controller)
-		self.set_image(os.path.join(self.app.imagepath, f"controller-images/{self.current["gui"]["background"]}.svg"))
+		self.set_image(os.path.join(self.app.imagepath, f"controller-images/{self.current['gui']['background']}.svg"))
 		if not self.current["gui"]["no_buttons_in_gui"]:
 			self._fill_button_images(self.current["gui"]["buttons"])
 		self.hilight({})


### PR DESCRIPTION
Fixes:
```
# DISPLAY=:0 ./sc-controller-v0.4.8.20-1-bookworm-x86_64.AppImage
Traceback (most recent call last):
  File "/tmp/.mount_sc-conqJTlym/usr/bin/sc-controller", line 27, in <module>
    from scc.gui.app import App
  File "/tmp/.mount_sc-conqJTlym/usr/lib/python/scc/gui/app.py", line 13, in <module>
    from scc.gui.controller_image import ControllerImage
  File "/tmp/.mount_sc-conqJTlym/usr/lib/python/scc/gui/controller_image.py", line 96
    self.set_image(os.path.join(self.app.imagepath, f"controller-images/{self.current["gui"]["background"]}.svg"))
                                                                                       ^^^
SyntaxError: f-string: unmatched '['
```