### PR TITLE
AppImage: increase compatibility & add tests

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -5,25 +5,45 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  BASE_OS: ubuntu
-  APT_PUBKEY: 871920D1991BC93C
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
       matrix:
         target:
           - platform: linux/amd64
             arch: amd64
           - platform: linux/arm64
             arch: arm64
-        codename:
-          - jammy
-          - noble
+        base:
+          - os: ubuntu
+            codename: focal
+            pubkey: 871920D1991BC93C
+            recipe: AppImageBuilder.ubuntu-focal.yml
+          - os: ubuntu
+            codename: jammy
+            pubkey: 871920D1991BC93C
+            recipe: AppImageBuilder.yml
+          - os: ubuntu
+            codename: noble
+            pubkey: 871920D1991BC93C
+            recipe: AppImageBuilder.yml
+          - os: debian
+            codename: bullseye
+            pubkey: 0E98404D386FA1D9
+            pubkey_security: 54404762BBB6E853
+            recipe: AppImageBuilder.debian-bullseye.yml
+          - os: debian
+            codename: bookworm
+            pubkey: 0E98404D386FA1D9
+            pubkey_security: 54404762BBB6E853
+            recipe: AppImageBuilder.debian.yml
+          - os: debian
+            codename: trixie
+            pubkey: 0E98404D386FA1D9
+            pubkey_security: 54404762BBB6E853
+            recipe: AppImageBuilder.debian.yml
 
     steps:
       - uses: actions/checkout@v4
@@ -42,8 +62,8 @@ jobs:
           platforms: ${{ matrix.target.platform }}
           outputs: build
           build-args: |
-            BASE_OS
-            BASE_CODENAME=${{ matrix.codename }}
+            BASE_OS=${{ matrix.base.os }}
+            BASE_CODENAME=${{ matrix.base.codename }}
 
       - name: Prepare environment to build AppImage
         env:
@@ -56,24 +76,85 @@ jobs:
             rm build/.build-metadata.env
           fi
           APPIMAGE_SOURCE=build
-          APPIMAGE_VERSION="${GITHUB_REF_SLUG}-${{ matrix.codename }}"
+          APPIMAGE_VERSION="${GITHUB_REF_SLUG}-${{ matrix.base.codename }}"
           APPIMAGE_APT_ARCH="${TARGETARCH}"
-          APPIMAGE_APT_DISTRO="${{ matrix.codename }}"
-          APPIMAGE_APT_PUBKEY="${APT_PUBKEY}"
+          APPIMAGE_APT_DISTRO="${{ matrix.base.codename }}"
+          APPIMAGE_APT_PUBKEY="${{ matrix.base.pubkey }}"
+          APPIMAGE_APT_PUBKEY_SECURITY="${{ matrix.base.pubkey_security }}"
           APPIMAGE_ARCH="${TARGETMACHINE}"
           printenv | grep ^APPIMAGE_ >>"${GITHUB_ENV}"
 
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@v1.3
+        with:
+          recipe: "${{ matrix.base.recipe }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: appimage-${{ matrix.codename }}-${{ matrix.target.arch }}
+          name: appimage-${{ matrix.base.codename }}-${{ matrix.target.arch }}
           path: |
             ./*.AppImage
             ./*.AppImage.zsync
           if-no-files-found: error
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - platform: linux/amd64
+            arch: amd64
+        base:
+          - os: ubuntu
+            codename: focal
+          - os: ubuntu
+            codename: jammy
+          - os: ubuntu
+            codename: noble
+          - os: debian
+            codename: bullseye
+          - os: debian
+            codename: bookworm
+          - os: debian
+            codename: trixie
+          - os: fedora
+            codename: "39"
+          - os: fedora
+            codename: "40"
+          - os: archlinux
+            codename: base
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: appimage-*-${{ matrix.target.arch }}
+          path: appimages
+          merge-multiple: true
+
+      - name: Setup qemu for docker
+        uses: docker/setup-qemu-action@v3
+        if: matrix.target.platform != 'linux/amd64'
+
+      - name: Setup buildx for docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test AppImages
+        uses: docker/build-push-action@v5
+        with:
+          file: AppImageBuilder.test.Dockerfile
+          context: appimages
+          platforms: ${{ matrix.target.platform }}
+          build-args: |
+            BASE_OS=${{ matrix.base.os }}
+            BASE_CODENAME=${{ matrix.base.codename }}
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -81,6 +162,7 @@ jobs:
 
     needs:
       - build
+      - test
 
     permissions:
       contents: write

--- a/AppImageBuilder.debian-bullseye.yml
+++ b/AppImageBuilder.debian-bullseye.yml
@@ -41,6 +41,11 @@ AppDir:
       fi
     done
 
+    # install python3-vdf manually if not available as package
+    if ! apt-cache search --names-only python3-vdf | grep -q .; then
+      pip install --target "${TARGET_APPDIR}/usr/lib/python3/dist-packages/" vdf
+    fi
+
   after_runtime: |
     set -eu
 
@@ -55,13 +60,11 @@ AppDir:
     arch:
       - "{{APPIMAGE_APT_ARCH}}"
     sources:
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ {{APPIMAGE_APT_DISTRO}} main universe
+      - sourceline: deb http://deb.debian.org/debian {{APPIMAGE_APT_DISTRO}} main
         key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY}}
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ {{APPIMAGE_APT_DISTRO}}-updates main universe
-      - sourceline: deb [arch=amd64] http://security.ubuntu.com/ubuntu/ {{APPIMAGE_APT_DISTRO}}-security main universe
-      - sourceline: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ {{APPIMAGE_APT_DISTRO}} main universe
-      - sourceline: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ {{APPIMAGE_APT_DISTRO}}-updates main universe
-      - sourceline: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ {{APPIMAGE_APT_DISTRO}}-security main universe
+      - sourceline: deb http://deb.debian.org/debian {{APPIMAGE_APT_DISTRO}}-updates main
+      - sourceline: deb http://deb.debian.org/debian-security/ {{APPIMAGE_APT_DISTRO}}-security main
+        key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY_SECURITY}}
 
     include:
       - gir1.2-gtk-3.0
@@ -76,7 +79,6 @@ AppDir:
       - python3-evdev
       - python3-gi-cairo
       - python3-pylibacl
-      - python3-vdf
       - binutils         # required for detection of bluetooth library
       - coreutils        # provides /usr/bin/env
       - shared-mime-info # required for gui if host provides no MIME info, e.g. when XDG_DATA_DIRS is missing
@@ -126,12 +128,23 @@ AppDir:
       - libuuid*        # development
       - media-types     # codec
 
-      # Ubuntu Noble
+      # Debian Trixie
       - libgprofng*     # development
       - libjansson*     # codec
       - libsframe*      # development
+      - libcloudproviders* # networking
       - netbase         # network
       - tzdata          # date/time
+
+      # Debian Bullseye
+      - glib-networking* # network
+      - gsettings*       # gui configuration
+      - libidn2*         # codec
+      - libjson*         # codec
+      - libpsl*          # networking
+      - librest-*        # networking
+      - libsoup*         # networking
+      - libunistring*    # unicode
 
   files:
     exclude:

--- a/AppImageBuilder.debian.yml
+++ b/AppImageBuilder.debian.yml
@@ -55,13 +55,11 @@ AppDir:
     arch:
       - "{{APPIMAGE_APT_ARCH}}"
     sources:
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ {{APPIMAGE_APT_DISTRO}} main universe
+      - sourceline: deb http://deb.debian.org/debian {{APPIMAGE_APT_DISTRO}} main
         key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY}}
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ {{APPIMAGE_APT_DISTRO}}-updates main universe
-      - sourceline: deb [arch=amd64] http://security.ubuntu.com/ubuntu/ {{APPIMAGE_APT_DISTRO}}-security main universe
-      - sourceline: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ {{APPIMAGE_APT_DISTRO}} main universe
-      - sourceline: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ {{APPIMAGE_APT_DISTRO}}-updates main universe
-      - sourceline: deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ {{APPIMAGE_APT_DISTRO}}-security main universe
+      - sourceline: deb http://deb.debian.org/debian {{APPIMAGE_APT_DISTRO}}-updates main
+      - sourceline: deb http://deb.debian.org/debian-security/ {{APPIMAGE_APT_DISTRO}}-security main
+        key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY_SECURITY}}
 
     include:
       - gir1.2-gtk-3.0
@@ -126,10 +124,11 @@ AppDir:
       - libuuid*        # development
       - media-types     # codec
 
-      # Ubuntu Noble
+      # Debian Trixie
       - libgprofng*     # development
       - libjansson*     # codec
       - libsframe*      # development
+      - libcloudproviders* # networking
       - netbase         # network
       - tzdata          # date/time
 

--- a/AppImageBuilder.test.Dockerfile
+++ b/AppImageBuilder.test.Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+ARG BASE_OS=ubuntu
+ARG BASE_CODENAME=noble
+FROM $BASE_OS:$BASE_CODENAME
+WORKDIR /tmp
+COPY *.AppImage /opt/
+RUN <<EOR
+  set -eu
+
+  log() {
+    echo >&2 "${@}"
+  }
+
+  cancel() {
+    log "${@}"
+    return 1
+  }
+
+  handle_failure() {
+    return_code="${1}"
+    file="${2}"
+    if [ "${return_code}" = 139 ] && echo "${file}" | grep -q -P -- '-(noble|trixie|bookworm)-'; then
+       log "Ignoring failure ${return_code} for ${file}" \
+           "which is currently known to cause a segmentation fault"
+    else
+      return "${return_code}"
+    fi
+  }
+
+  main() {
+    files="$(find /opt/ -maxdepth 1 -type f -name '*.AppImage')"
+    if [ -z "${files}" ]; then
+      cancel "Error: No AppImage file found."
+    fi
+    echo "${files}" | while read -r file; do
+      log "${file}"
+      chmod +x "${file}"
+      rm -rf squashfs-root/
+      "${file}" --appimage-extract >/dev/null
+      (
+       cd squashfs-root/runtime/compat
+       ../../AppRun dependency-check || handle_failure "$?" "${file}"
+      )
+      rm -f "${file}"
+    done
+  }
+  main "${@}"
+EOR

--- a/AppImageBuilder.ubuntu-focal.yml
+++ b/AppImageBuilder.ubuntu-focal.yml
@@ -41,6 +41,11 @@ AppDir:
       fi
     done
 
+    # install python3-vdf manually if not available as package
+    if ! apt-cache search --names-only python3-vdf | grep -q .; then
+      pip install --target "${TARGET_APPDIR}/usr/lib/python3/dist-packages/" vdf
+    fi
+
   after_runtime: |
     set -eu
 
@@ -76,7 +81,6 @@ AppDir:
       - python3-evdev
       - python3-gi-cairo
       - python3-pylibacl
-      - python3-vdf
       - binutils         # required for detection of bluetooth library
       - coreutils        # provides /usr/bin/env
       - shared-mime-info # required for gui if host provides no MIME info, e.g. when XDG_DATA_DIRS is missing
@@ -125,6 +129,15 @@ AppDir:
       - libtirpc*       # development
       - libuuid*        # development
       - media-types     # codec
+
+      # Ubuntu Focal
+      - glib-networking* # network
+      - gsettings*       # gui configuration
+      - libidn2*         # codec
+      - libjson*         # codec
+      - libsoup*         # networking
+      - libunistring*    # unicode
+      - mime-support     # codec
 
       # Ubuntu Noble
       - libgprofng*     # development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
+# syntax=docker/dockerfile:1
 ARG BASE_OS=ubuntu
 ARG BASE_CODENAME=noble
 FROM $BASE_OS:$BASE_CODENAME AS build-stage
 
 # Download build dependencies
 RUN <<EOR
-apt-get update
-apt-get install -y --no-install-recommends \
-	gcc \
-	librsvg2-bin \
-	linux-headers-generic \
-	python3-dev \
-	python3-setuptools \
-	python-is-python3
-apt-get clean && rm -rf /var/lib/apt/lists/*
+  set -eu
+
+  apt-get update
+  apt-get install -y --no-install-recommends \
+	  gcc \
+	  librsvg2-bin \
+	  linux-headers-generic \
+	  python3-dev \
+	  python3-setuptools \
+	  python-is-python3
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 EOR
 # Prepare working directory and target
 COPY . /work
@@ -21,28 +24,30 @@ ARG TARGET=/build/usr
 
 # Build and install
 RUN <<EOR
-python setup.py build --executable "/usr/bin/env python3"
-python setup.py install --single-version-externally-managed --home "${TARGET}" --record /dev/null
+  set -eu
 
-# Provide input-event-codes.h as fallback for runtime systems without linux headers
-cp -a \
-	"$(find /usr -type f -name input-event-codes.h -print -quit)" \
-	"$(find "${TARGET}" -type f -name uinput.py -printf '%h\n' -quit)"
+  python setup.py build --executable "/usr/bin/env python3"
+  python setup.py install --single-version-externally-managed --home "${TARGET}" --record /dev/null
 
-# Create short name symlinks for static libraries
-suffix=".cpython-*-$(uname -m)-linux-gnu.so"
-find "${TARGET}" -type f -path "*/site-packages/*${suffix}" \
-	| while read -r path; do ln -sfr "${path}" "${path%${suffix}}.so"; done
+  # Provide input-event-codes.h as fallback for runtime systems without linux headers
+  cp -a \
+	  "$(find /usr -type f -name input-event-codes.h -print -quit)" \
+	  "$(find "${TARGET}" -type f -name uinput.py -printf '%h\n' -quit)"
 
-# Put AppStream metadata to required location according to https://wiki.debian.org/AppStream/Guidelines
-metainfo=/build/usr/share/metainfo
-mkdir -p "${metainfo}"
-cp -a scripts/sc-controller.appdata.xml "${metainfo}"
+  # Create short name symlinks for static libraries
+  suffix=".cpython-*-$(uname -m)-linux-gnu.so"
+  find "${TARGET}" -type f -path "*/site-packages/*${suffix}" \
+    | while read -r path; do ln -sfr "${path}" "${path%${suffix}}.so"; done
 
-# Convert icon to png format (required for icons in .desktop file)
-iconpath="${TARGET}/share/icons/hicolor/512x512/apps"
-mkdir -p "${iconpath}"
-rsvg-convert --background-color none -o "${iconpath}/sc-controller.png" images/sc-controller.svg
+  # Put AppStream metadata to required location according to https://wiki.debian.org/AppStream/Guidelines
+  metainfo=/build/usr/share/metainfo
+  mkdir -p "${metainfo}"
+  cp -a scripts/sc-controller.appdata.xml "${metainfo}"
+
+  # Convert icon to png format (required for icons in .desktop file)
+  iconpath="${TARGET}/share/icons/hicolor/512x512/apps"
+  mkdir -p "${iconpath}"
+  rsvg-convert --background-color none -o "${iconpath}/sc-controller.png" images/sc-controller.svg
 EOR
 
 # Store build metadata


### PR DESCRIPTION
This PR aims to improve the compatibility of created AppImages.

#### Current Problems
The current AppImages are based on Ubuntu LTS releases Jammy and Noble. They crash on some environments, at least:
1. On Batocera 40 as [reported here](https://github.com/C0rn3j/sc-controller/pull/3#issuecomment-2184786389).
    The commented environment requires an AppImage build based on Ubuntu Lunar while Lunar is EOL.
2. On Debian 12 as [reported here](https://github.com/C0rn3j/sc-controller/issues/15#issue-2499639791)

#### Causes
The crashes have different causes:
1. The AppImage does not contain all required libraries. Thus some libraries are loaded from the host system. These are sometimes incompatible to other contained libraries.
2. The AppImage is based on a glibc that is newer than the host.
4. The directory tree within the AppImage is incompatible to the tree of current OS distros (i.e. using AppImageBuilder to build an AppImage basd on Ubuntu Noble creates an invalid AppImage).

The AppImage documentation explains some [concepts](https://docs.appimage.org/introduction/concepts.html) which are important for compatibility, e.g.:
> - Build on old systems, run on newer systems
> - Do not depend on system-provided resources

The current AppImages are not based on these concepts.

#### Solutions
1. Library exclusions have been revisited.
2. According to the first concept ("Build on old systems"), additional AppImages are built for popular Debian-based distributions:

    | OS     | Codename | glibc | python3-gi | libglib2.0 |
    |--------|----------|-------|------------|--------------|
    | Ubuntu | Focal    | 2.31  | 3.36       | 2.64  |
    | Ubuntu | Jammy    | 2.35  | 3.42       | 2.66  |
    | Ubuntu | Noble    | 2.39  | 3.48       | 2.80  |
    | Debian | Bullseye | 2.31  | 3.38       | 2.66  |
    | Debian | Bookworm | 2.36  | 3.42       | 2.74  |
    | Debian | Trixie   | 2.39  | 3.48       | 2.82  |
4. The build contains a test job that runs sc-controller with the existing `check-dependency` argument. A build success now means that a) all required dependencies are part of the AppImage and b) the libraries are compatible to the host systems (at least to the extent of `check-dependency`). The test job runs in a Docker container for several popular linux distributions:
    - Ubuntu Focal, Jammy, Noble
    - Debian Bullseye, Bookworm, Trixie
    - Fedora 39 , 40
    - ArchLinux

#### Implementation notes
- The error reported in https://github.com/C0rn3j/sc-controller/issues/15 is fixed. It was caused by a missing `/lib64` directory in Ubuntu Noble.
- Excluded libraries have been revisited to avoid crashes. The new AppImages are slightly bigger, but more compatible now.
- Debian Bullseye and Ubuntu Focal require a separate `AppImageBuilder.yml` because no apt package `python3-vdf` exists for these distributions. When they run EOL, these extra files can be deleted.
- The tests run on `amd64` arch only (I didn't figure out how to run them on `arm64`).
- A GitHub [Action result](https://github.com/git-developer/sc-controller/actions/runs/10752092467) and [Release](https://github.com/git-developer/sc-controller/releases/tag/v0.4.8.20-2) is available.
- Currently, the most compatible Appmage is based on Ubuntu Jammy. But since the test only checks the dependencies and doesn't really use the application, I didn't remove the other AppImages so that users have the choice.

### Known issues
There's an open compatibility issue concerning the AppImages for newer AppImages (primarily Ubuntu Noble & Debian Trixie). They cause a segmentation fault on most distributions. The test job knows about this issue and does not fail. Here is the summary of some manual and CI tests:

|Host |||     |   | AppImage |       |          |          |          |          |
|-----------|----------|----------|-------|---|----------|-------|----------|----------|----------|----------|
| **OS**        | **Codename** | **Kernel**   | **glibc** |   | **Focal**    | **Jammy** | **Noble**    | **Bullseye** | **Bookworm** | **Trixie**   |
| Ubuntu    | Jammy    | 5.15     | 2.35  |   | OK       | OK    | SEGFAULT | OK       | SEGFAULT | SEGFAULT |
| Ubuntu    | Noble    | 6.8      | 2.39  |   | OK       | OK    | SEGFAULT | OK       | OK       | SEGFAULT |
| Batocera  | 40       | 6.9      | 2.38  |   | OK       | OK    | SEGFAULT | OK       | OK       | SEGFAULT |
| | | | | | | | | | | |
| Fedora    | 39       | GitHub | 2.38   |   | OK       | OK    | SEGFAULT | OK       | OK       | SEGFAULT |
| Fedora    | 40       | GitHub | 2.39 |   | OK       | OK    | SEGFAULT | OK       | OK       | SEGFAULT |
| Ubuntu    | Focal    | GitHub | 2.31  |   | OK       | OK    | SEGFAULT | OK       | SEGFAULT | SEGFAULT |
| Ubuntu    | Jammy    | GitHub | 2.35  |   | OK       | OK    | SEGFAULT | OK       | SEGFAULT | SEGFAULT |
| Ubuntu    | Noble    | GitHub | 2.39  |   | OK       | OK    | SEGFAULT | OK       | OK       | SEGFAULT |
| Debian    | Bullseye | GitHub | 2.31 |   | OK       | OK    | SEGFAULT | OK       | SEGFAULT | SEGFAULT |
| Debian    | Bookworm | GitHub | 2.36  |   | OK       | OK    | SEGFAULT | OK       | SEGFAULT | SEGFAULT |
| Debian    | Trixie   | GitHub | 2.39 |   | OK       | OK    | OK       | OK       | OK       | OK       |
| ArchLinux | 2024-09-07 | GitHub | 2.40 |   | OK       | OK    | OK       | OK       | OK       | OK       |

The segmentation fault occurs in `ld-linux-x86-64.so.2` (part of glibc) loaded by the `python3` process. The kernel reports
```
segfault at 7fec1b53e014 ip 00007fc81bc8dd57 sp 00007ffdad0b0490 error 6 in ld-linux-x86-64.so.2[7fc81bc81000+25000]
[2057583.497148] Code: 30 48 0f 44 d0 49 8b 87 58 01 00 00 48 8b 70 08 48 01 d6 48 39 f2 73 63 31 ff eb 1a 0f 1f 80 00 00 00 00 4c 01 f0 48 83 c2 08 <4c> 01 30 48 8d 78 08 48 39 f2 73 35 48 8b 02 a8 01 74 e6 48 d1 e8
```