### PR TITLE
Fix type error on Bullseye

### DIFF
--- a/scc/device_monitor.py
+++ b/scc/device_monitor.py
@@ -191,7 +191,7 @@ class DeviceMonitor(Monitor):
 					self._on_new_syspath(subsystem, syspath)
 
 
-	def get_vendor_product(self, syspath: str, subsystem: str | None = None) -> tuple[int, int]:
+	def get_vendor_product(self, syspath: str, subsystem) -> tuple[int, int]:
 		"""For given syspath, reads and returns (vendor_id, product_id) as ints.
 
 		May throw all kinds of OSErrors

--- a/scc/device_monitor.py
+++ b/scc/device_monitor.py
@@ -191,7 +191,7 @@ class DeviceMonitor(Monitor):
 					self._on_new_syspath(subsystem, syspath)
 
 
-	def get_vendor_product(self, syspath: str, subsystem=None) -> tuple[int, int]:
+	def get_vendor_product(self, syspath: str, subsystem: "str | None" = None) -> tuple[int, int]:
 		"""For given syspath, reads and returns (vendor_id, product_id) as ints.
 
 		May throw all kinds of OSErrors

--- a/scc/device_monitor.py
+++ b/scc/device_monitor.py
@@ -191,7 +191,7 @@ class DeviceMonitor(Monitor):
 					self._on_new_syspath(subsystem, syspath)
 
 
-	def get_vendor_product(self, syspath: str, subsystem) -> tuple[int, int]:
+	def get_vendor_product(self, syspath: str, subsystem=None) -> tuple[int, int]:
 		"""For given syspath, reads and returns (vendor_id, product_id) as ints.
 
 		May throw all kinds of OSErrors


### PR DESCRIPTION
Fix for a crash caused by a change from [2850ecd](https://github.com/C0rn3j/sc-controller/commit/2850ecdee918da723ccfc4195bc4f1727f5e7c5a):
```
# ./sc-controller-v0.4.8.21-1-bullseye-x86_64.AppImage daemon debug
Traceback (most recent call last):
  File "/tmp/.mount_sc-conytlXRP/usr/bin/scc-daemon", line 2, in <module>
    from scc.sccdaemon import SCCDaemon
  File "/tmp/.mount_sc-conytlXRP/usr/lib/python/scc/sccdaemon.py", line 15, in <module>
    from scc.device_monitor import create_device_monitor
  File "/tmp/.mount_sc-conytlXRP/usr/lib/python/scc/device_monitor.py", line 35, in <module>
    class DeviceMonitor(Monitor):
  File "/tmp/.mount_sc-conytlXRP/usr/lib/python/scc/device_monitor.py", line 196, in DeviceMonitor
    def get_vendor_product(self, syspath: str, subsystem: str | None = None) -> Tuple[int, int]:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
