### PR TITLE
Avoid crash when starting `daemon debug` in v0.4.9

### DIFF
--- a/AppImageBuilder.test.Dockerfile
+++ b/AppImageBuilder.test.Dockerfile
@@ -39,7 +39,7 @@ RUN <<EOR
       "${file}" --appimage-extract >/dev/null
       (
        cd squashfs-root/runtime/compat
-       ../../AppRun dependency-check || handle_failure "$?" "${file}"
+       { ../../AppRun dependency-check && ../../AppRun daemon --help; } || handle_failure "$?" "${file}"
       )
       rm -f "${file}"
     done

--- a/scc/parser.py
+++ b/scc/parser.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import sys
 import token as TokenType
-from enum import EnumType
 from tokenize import TokenError, generate_tokens
 from typing import NamedTuple
 

--- a/scc/uinput.py
+++ b/scc/uinput.py
@@ -45,20 +45,16 @@ else:
 MAX_FEEDBACK_EFFECTS = 4
 
 # Keys enum contains all keys and button from linux/uinput.h (KEY_* BTN_*)
-class Keys(IntEnum):
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith(("KEY_", "BTN_"))})
+Keys = IntEnum('Keys', {i: CHEAD[i] for i in CHEAD.keys() if (i.startswith('KEY_') or i.startswith('BTN_'))})
 
 # Keys enum contains all keys and button from linux/uinput.h (KEY_* BTN_*)
-class KeysOnly(IntEnum):
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith("KEY_")})
+KeysOnly = IntEnum('KeysOnly', {i: CHEAD[i] for i in CHEAD.keys() if i.startswith('KEY_')})
 
 # Axes enum contains all axes from linux/uinput.h (ABS_*)
-class Axes(IntEnum):
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith("ABS_")})
+Axes = IntEnum('Axes', {i: CHEAD[i] for i in CHEAD.keys() if i.startswith('ABS_')})
 
 # Rels enum contains all rels from linux/uinput.h (REL_*)
-class Rels(IntEnum):
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith("REL_")})
+Rels = IntEnum('Rels', {i: CHEAD[i] for i in CHEAD.keys() if i.startswith('REL_')})
 
 # Scan codes for each keys (taken from a logitech keyboard)
 Scans = {


### PR DESCRIPTION
Some of the changes towards v0.4.9 introduce a crash when starting the daemon. This PR is a workaround for these crashes.

Feel free to modify, I just reverted changes until starting with args `daemon debug` does not crash anymore.

Addresses https://github.com/C0rn3j/sc-controller/issues/24