### PR TITLE
AppImage: fix segfault

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -85,9 +85,15 @@ jobs:
           printenv | grep ^APPIMAGE_ >>"${GITHUB_ENV}"
 
       - name: Build AppImage
-        uses: AppImageCrafters/build-appimage@v1.3
+        uses: git-developer/build-appimage@v1.3
         with:
-          recipe: "${{ matrix.base.recipe }}"
+          command: ${{
+                     format('sh -c "set -eu; {0}; {1}; {2}; appimage-builder --recipe {3}"',
+                       'pip install --upgrade setuptools packaging packaging-legacy',
+                       'pip install --extra-index-url https://lief.s3-website.fr-par.scw.cloud/latest \"lief>=0.16.0.dev0\"',
+                       'find /usr/local/lib -name package.py | while read -r file; do sed -i -e \"s/^from.packaging/&_legacy/\" \"${file}\"; done',
+                       matrix.base.recipe)
+                   }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/AppImageBuilder.debian-bullseye.yml
+++ b/AppImageBuilder.debian-bullseye.yml
@@ -76,6 +76,13 @@ AppDir:
       pip install --target "${TARGET_APPDIR}/usr/lib/python3/dist-packages/" vdf
     fi
 
+    # python3-usb1 expects 'libusb-1.0.so', see https://github.com/vpelletier/python-libusb1/issues/78
+    find "${TARGET_APPDIR}" -name 'libusb-1.0.so.[0-9]' | while read -r file; do
+      path="$(dirname "${file}")"
+      link="${file%.[0-9]}"
+      [ -e "${link}" ] || ln -sr "${file}" "${link}"
+    done
+
   apt:
     arch:
       - "{{APPIMAGE_APT_ARCH}}"
@@ -104,8 +111,6 @@ AppDir:
 
     exclude:
       # coreutils
-      - libacl*         # filesystem
-      - libattr*        # filesystem
       - libgmp*         # arithmetics
 
       # gir1.2-rsvg-2.0

--- a/AppImageBuilder.debian.yml
+++ b/AppImageBuilder.debian.yml
@@ -71,6 +71,20 @@ AppDir:
       printf '[Settings]\ngtk-icon-theme-name = %s\n' "${theme}" >"${xdg_settings}"
     fi
 
+    # python3-usb1 expects 'libusb-1.0.so', see https://github.com/vpelletier/python-libusb1/issues/78
+    find "${TARGET_APPDIR}" -name 'libusb-1.0.so.[0-9]' | while read -r file; do
+      path="$(dirname "${file}")"
+      link="${file%.[0-9]}"
+      [ -e "${link}" ] || ln -sr "${file}" "${link}"
+    done
+
+    # Trixie expects libpixbufloader libs with a dash suffix, not underscore
+    find "${TARGET_APPDIR}" -type f -name 'libpixbufloader_*' | while read -r file; do
+      path="$(dirname "${file}")"
+      link="${path}/$(echo "$(basename "${file}")" | tr _ -)"
+      [ -e "${link}" ] || ln -sr "${file}" "${link}"
+    done
+
   after_runtime: |
     set -eu
 
@@ -109,8 +123,6 @@ AppDir:
 
     exclude:
       # coreutils
-      - libacl*         # filesystem
-      - libattr*        # filesystem
       - libgmp*         # arithmetics
 
       # gir1.2-rsvg-2.0
@@ -134,7 +146,6 @@ AppDir:
       - libfribidi*     # i18n
       - libgtk-3-common # gui
       - liblz*          # codec
-      - libmount*       # filesystem
       - libtiff*        # codec
       - libwebp*        # codec
 
@@ -156,7 +167,6 @@ AppDir:
       - libgprofng*     # development
       - libjansson*     # codec
       - libsframe*      # development
-      - libcloudproviders* # networking
       - netbase         # network
       - tzdata          # date/time
 

--- a/AppImageBuilder.debian.yml
+++ b/AppImageBuilder.debian.yml
@@ -79,6 +79,7 @@ AppDir:
     done
 
     # Trixie expects libpixbufloader libs with a dash suffix, not underscore
+    # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1082676
     find "${TARGET_APPDIR}" -type f -name 'libpixbufloader_*' | while read -r file; do
       path="$(dirname "${file}")"
       link="${path}/$(echo "$(basename "${file}")" | tr _ -)"

--- a/AppImageBuilder.ubuntu-focal.yml
+++ b/AppImageBuilder.ubuntu-focal.yml
@@ -76,6 +76,13 @@ AppDir:
       printf '[Settings]\ngtk-icon-theme-name = %s\n' "${theme}" >"${xdg_settings}"
     fi
 
+    # python3-usb1 expects 'libusb-1.0.so', see https://github.com/vpelletier/python-libusb1/issues/78
+    find "${TARGET_APPDIR}" -name 'libusb-1.0.so.[0-9]' | while read -r file; do
+      path="$(dirname "${file}")"
+      link="${file%.[0-9]}"
+      [ -e "${link}" ] || ln -sr "${file}" "${link}"
+    done
+
   apt:
     arch:
       - "{{APPIMAGE_APT_ARCH}}"
@@ -108,8 +115,6 @@ AppDir:
 
     exclude:
       # coreutils
-      - libacl*         # filesystem
-      - libattr*        # filesystem
       - libgmp*         # arithmetics
 
       # gir1.2-rsvg-2.0

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -71,6 +71,13 @@ AppDir:
       printf '[Settings]\ngtk-icon-theme-name = %s\n' "${theme}" >"${xdg_settings}"
     fi
 
+    # python3-usb1 expects 'libusb-1.0.so', see https://github.com/vpelletier/python-libusb1/issues/78
+    find "${TARGET_APPDIR}" -name 'libusb-1.0.so.[0-9]' | while read -r file; do
+      path="$(dirname "${file}")"
+      link="${file%.[0-9]}"
+      [ -e "${link}" ] || ln -sr "${file}" "${link}"
+    done
+
   after_runtime: |
     set -eu
 
@@ -111,8 +118,6 @@ AppDir:
 
     exclude:
       # coreutils
-      - libacl*         # filesystem
-      - libattr*        # filesystem
       - libgmp*         # arithmetics
 
       # gir1.2-rsvg-2.0
@@ -136,7 +141,6 @@ AppDir:
       - libfribidi*     # i18n
       - libgtk-3-common # gui
       - liblz*          # codec
-      - libmount*       # filesystem
       - libtiff*        # codec
       - libwebp*        # codec
 


### PR DESCRIPTION
This PR contains several AppImage fixes, including a segmentation fault reported in https://github.com/C0rn3j/sc-controller/pull/17.

GitHub [release]() and [action run](https://github.com/git-developer/sc-controller/actions/runs/11081842693) are available (1 test failed because of outstanding https://github.com/C0rn3j/sc-controller/pull/31).

### Segmentation fault
The AppImages based on Debian Trixie and Ubuntu Noble currently cause a segmentation fault. Both distros use glibc 2.39. When building an AppImage for Trixie, the following message is shown:
```
Can't find string offset for section name '.note.cafe1a7e'
```
This message arises from LIEF, a library used to patch binary files. Debugging uncovered that the messages occur when `libc.so.6` is patched. Apparently, libc contains something that LIEF is not able to handle. In 07/2024, https://github.com/lief-project/LIEF/pull/1081 was merged, adding _support new dynamic tags for x86\_64_. When lief is updated to a version containing these changes (currently available: pre-release `0.16.0.dev0`), the messages are gone and no segfault occurs.

This LIEF update should be made upstream in AppImageBuilder. Until that is done, we perform it as first step when the existing AppImageBuilder Docker image is run. Since the provided GitHub action does not support such pre-processing, a customized action is used (calling the original Docker image). When the upstream Docker image and GitHub action are updated, this customization is obsolete.

The special segfault handling in the AppImage tests have been removed.

### Error loading `libusb-1.0`
In Debian-based distros without `libusb-dev`, python-libusb1 fails to load `libusb-1.0`. The problem was reported upstream in https://github.com/vpelletier/python-libusb1/issues/78. https://github.com/C0rn3j/sc-controller/pull/31 covers the same problem for `libudev`. Until the problem is fixed upstream, a symlink is created from`libusb-1.0.so` to `libusb-1.0.so.1` as workaround.

### Dependencies
While debugging the problems above, it turned out that some of the currently excluded libraries are actually used (`acl`, `attr`, `mount`, `cloudproviders`). Although currently no errors are known caused by these missing libraries, it's never a good idea to mix libraries between host and AppImage. Therefore, these libs are now removed from the excludes.

### `libpixbufloader` for SVG
In Debian Trixie, the package `librsvg2-common` no longer provides `libpixbufloader-svg.so` but `libpixbufloader_svg.so` (dash vs. underscore). Reported upstream as [#1082676](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1082676). A symlink is added as workaround.
