### PR TITLE
Fix return code when subprocess fails

### DIFF
--- a/AppImageBuilder.test.Dockerfile
+++ b/AppImageBuilder.test.Dockerfile
@@ -16,17 +16,6 @@ RUN <<EOR
     return 1
   }
 
-  handle_failure() {
-    return_code="${1}"
-    file="${2}"
-    if [ "${return_code}" = 139 ] && echo "${file}" | grep -q -P -- '-(noble|trixie|bookworm)-'; then
-      log "Ignoring failure ${return_code} for ${file}" \
-          "which is currently known to cause a segmentation fault"
-    else
-      return "${return_code}"
-    fi
-  }
-
   prepare() {
     if command -v apt-get >/dev/null; then
       apt-get update && apt-get install -y --no-install-recommends libx11-6
@@ -43,14 +32,19 @@ RUN <<EOR
       cancel "Error: No AppImage file found."
     fi
     prepare
+    config_path="${HOME}/.config/scc"
+    mkdir -p "${config_path}"
+    echo '{}' >"${config_path}/config.json"
+
     echo "${files}" | while read -r file; do
-      log "${file}"
+      log "Testing ${file}"
       chmod +x "${file}"
       rm -rf squashfs-root/
       "${file}" --appimage-extract >/dev/null
       (
         cd squashfs-root/runtime/compat
-        { ../../AppRun dependency-check && ../../AppRun daemon --help; } || handle_failure "$?" "${file}"
+        ../../AppRun dependency-check
+        ../../AppRun daemon --help
       )
       rm -f "${file}"
     done

--- a/scc/scripts.py
+++ b/scc/scripts.py
@@ -9,29 +9,30 @@ import os, sys, subprocess
 
 class InvalidArguments(Exception): pass
 
+def run_binary(binary_name: str, argv: list[str]) -> int:
+	binary = find_binary(binary_name)
+	child = subprocess.Popen([binary] + argv)
+	child.communicate()
+	return child.returncode
 
 def cmd_daemon(argv0, argv):
 	""" Controls scc-daemon """
 	# Actually just passes parameters to scc-daemon
-	scc_daemon = find_binary("scc-daemon")
-	subprocess.Popen([scc_daemon] + argv).communicate()
+	return run_binary("scc-daemon", argv)
 
 
 def help_daemon():
-	scc_daemon = find_binary("scc-daemon")
-	subprocess.Popen([scc_daemon, "--help"]).communicate()
+	return run_binary("scc-daemon", ["--help"])
 
 
 def cmd_gui(argv0, argv):
 	""" Starts GUI """
 	# Passes parameters to sc-controller
-	scc_daemon = find_binary("sc-controller")
-	subprocess.Popen([scc_daemon] + argv).communicate()
+	return run_binary("sc-controller", argv)
 
 
 def help_gui():
-	scc_daemon = find_binary("sc-controller")
-	subprocess.Popen([scc_daemon, "--help"]).communicate()
+	return run_binary("sc-controller", ["--help"])
 
 
 def cmd_test_evdev(argv0, argv):

--- a/scc/scripts.py
+++ b/scc/scripts.py
@@ -9,7 +9,7 @@ import os, sys, subprocess
 
 class InvalidArguments(Exception): pass
 
-def run_binary(binary_name: str, argv: list[str]) -> int:
+def run_binary(binary_name, argv):
 	binary = find_binary(binary_name)
 	child = subprocess.Popen([binary] + argv)
 	child.communicate()


### PR DESCRIPTION
This PR fixes the following problem: when a subprocess fails, the application returns with exit code 0.

This behaviour complicates AppImage tests because output must be parsed to check if a test failed.

A GitHub Action run is [available](https://github.com/git-developer/sc-controller/actions/runs/11083367831)