### PR TITLE
Appimage: create a Draft Release on manual builds

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -163,7 +163,6 @@ jobs:
             BASE_CODENAME=${{ matrix.base.codename }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     needs:
@@ -190,4 +189,5 @@ jobs:
       - name: Upload artifacts to GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          draft: ${{ !startsWith(github.ref, 'refs/tags/') }}
           files: assets/*


### PR DESCRIPTION
This PR is meant as a little improvement for release management.

Currently, you're able to manually trigger a CI build to see if build and tests are OK for a branch. The `release` step is skipped in this case, so artifacts have to be downloaded from the Action Run.

With this PR, every manually triggered build creates a _Draft Release_ containing the build artifacts as usual. See [here](https://github.com/git-developer/sc-controller/releases) for an example.

This might be an alternative to the creation of a Release for the purpose of testing or debugging.