### PR TITLE
Migrate from evdevice.fn to evdevice.path

### DIFF
--- a/scc/gui/creg/dialog.py
+++ b/scc/gui/creg/dialog.py
@@ -556,7 +556,7 @@ class ControllerRegistration(Editor):
 					self._tester = Tester("hid", "%.4x:%.4x" % (
 						self._evdevice.info.vendor, self._evdevice.info.product))
 				else:
-					self._tester = Tester("evdev", self._evdevice.fn)
+					self._tester = Tester("evdev", self._evdevice.path)
 				self._tester.__signals = [
 					self._tester.connect('ready', self.on_registration_ready),
 					self._tester.connect('error', self.on_device_open_failed),


### PR DESCRIPTION
Issue #74 and the [commit](https://github.com/C0rn3j/sc-controller/commit/03f51c8c80997ae91b4582d273c88ebc12e7cf93) which implemented the fix described in it missed a second reference to the deprecated and now removed `InputDevice.fn`. This causes similar behavior to the one described in the issue, with the exception that it now only occurs when changing the 'Access Mode' to evdev in the 'Advanced Settings' section while setting up the controller. This PR implements the fix for the problem.