### PR TITLE
Add missing GUI dependencies to AppImage

### DIFF
--- a/AppImageBuilder.debian.yml
+++ b/AppImageBuilder.debian.yml
@@ -113,6 +113,9 @@ AppDir:
       - libgtk-3-0
       - libgtk-layer-shell-dev
       - librsvg2-common
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-egl1
       - python-is-python3
       - python3-evdev
       - python3-gi-cairo

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -107,6 +107,9 @@ AppDir:
       - libgtk-3-0
       - libgtk-layer-shell-dev
       - librsvg2-common
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-egl1
       - python-is-python3
       - python3-evdev
       - python3-gi-cairo


### PR DESCRIPTION
The GUI fails to start when the latest AppImage (v0.5.4) is run, at least on batocera (v42):
```
$ ./sc-controller-0.5.4-jammy-x86_64.AppImage gui
** (process:8247): WARNING **: 16:00:27.579: Failed to load shared library 'libgdk-3.so.0' referenced by the typelib: libwayland-cursor.so.0: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/tmp/.mount_sc-con6cTGDx/usr/bin/sc-controller", line 8, in <module>
    sys.exit(main())
[...]
AssertionError
```

This seems to happen due to a missing dependency:

```
$ ./sc-controller-0.5.4-jammy-x86_64.AppImage --appimage-extract
$ ldd squashfs-root/usr/lib/x86_64-linux-gnu/libgdk-3.so.0
[...]
	libwayland-cursor.so.0 => not found
	libwayland-egl.so.1 => not found
	libwayland-client.so.0 => not found
```

Fix was tested against a [custom AppImage build](https://github.com/git-developer/sc-controller/actions/runs/18616962969)