### PR TITLE
update(ci): restore tests on debian trixie and fedora

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -30,14 +30,15 @@ jobs:
             pubkey: 54404762BBB6E853
             pubkey_security: 6ED0E7B82643E131
             recipe: AppImageBuilder.debian.yml
-#          - os: debian
-#            codename: trixie
-#            pubkey: 0E98404D386FA1D9
-#            pubkey_security: 54404762BBB6E853
-#            recipe: AppImageBuilder.debian.yml
+          - os: debian
+            codename: trixie
+            pubkey: BDE6D2B9216EC7A8
+            pubkey_security: 8E9F831205B4BA95
+            pubkey_updates: 78DBA3BC47EF2265
+            recipe: AppImageBuilder.debian.yml
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: rlespinasse/github-slug-action@v4
@@ -74,6 +75,7 @@ jobs:
           APPIMAGE_APT_ARCH="${TARGETARCH}"
           APPIMAGE_APT_DISTRO="${{ matrix.base.codename }}"
           APPIMAGE_APT_PUBKEY="${{ matrix.base.pubkey }}"
+          APPIMAGE_APT_PUBKEY_UPDATES="${{ matrix.base.pubkey_updates }}"
           APPIMAGE_APT_PUBKEY_SECURITY="${{ matrix.base.pubkey_security }}"
           APPIMAGE_ARCH="${TARGETMACHINE}"
           printenv | grep ^APPIMAGE_ >>"${GITHUB_ENV}"
@@ -99,7 +101,7 @@ jobs:
           if-no-files-found: error
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.target.os }}
     needs:
       - build
     strategy:
@@ -108,6 +110,17 @@ jobs:
         target:
           - platform: linux/amd64
             arch: amd64
+            os: ubuntu-latest
+
+          # arm64 AppImages created by appimage-builder <= v1.1.0 are broken
+          # and fail with `APPRUN_ERROR: No such file or directory` on amd64
+          # due to https://github.com/AppImageCrafters/appimage-builder/issues/272
+          #
+          # This comment can be removed when a fixed appimage-builder release is available.
+          #- platform: linux/arm64
+          #  arch: arm64
+          #  os: ubuntu-24.04-arm
+
         base:
           - os: ubuntu
             codename: jammy
@@ -115,30 +128,23 @@ jobs:
             codename: noble
           - os: debian
             codename: bookworm
-# ARM64 builds fail for Trixie and F41, something in the dockerfile throws code 139 and it segfaults
-#          - os: debian
-#            codename: trixie
-#          - os: fedora
-#            codename: "41"
+          - os: debian
+            codename: trixie
           - os: fedora
-            codename: "40"
-          - os: archlinux
-            codename: base
+            codename: "41"
+          - os: fedora
+            codename: "42"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: appimage-*-${{ matrix.target.arch }}
           path: appimages
           merge-multiple: true
-
-      - name: Setup qemu for docker
-        uses: docker/setup-qemu-action@v3
-        if: matrix.target.platform != 'linux/amd64'
 
       - name: Setup buildx for docker
         uses: docker/setup-buildx-action@v3
@@ -165,7 +171,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: appimage-*
           path: assets

--- a/AppImageBuilder.debian.yml
+++ b/AppImageBuilder.debian.yml
@@ -103,6 +103,7 @@ AppDir:
       - sourceline: deb http://deb.debian.org/debian {{APPIMAGE_APT_DISTRO}} main
         key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY}}
       - sourceline: deb http://deb.debian.org/debian {{APPIMAGE_APT_DISTRO}}-updates main
+        key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY_UPDATES}}
       - sourceline: deb http://deb.debian.org/debian-security/ {{APPIMAGE_APT_DISTRO}}-security main
         key_url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x{{APPIMAGE_APT_PUBKEY_SECURITY}}
 

--- a/AppImageBuilder.test.Dockerfile
+++ b/AppImageBuilder.test.Dockerfile
@@ -22,7 +22,7 @@ RUN <<EOR
     elif command -v pacman >/dev/null; then
       pacman -Syu --noconfirm libx11
     elif command -v dnf >/dev/null; then
-      dnf list updates && dnf install -y libX11
+      dnf install -y libX11
     fi
   }
 


### PR DESCRIPTION
I noticed that the build of Debian Trixie and tests on Trixie and Fedora have been disabled due to

> ARM64 builds fail for Trixie and F41

This seems not to occur anymore.

This PR adjusts:

* Reinstantiate the build of Debian Trixie
* Reinstantiate the tests on Debian Trixie, Fedora 41 and Fedora 42
* Remove tests on Fedora 40 (EOL)
* Remove tests on Arch (due to segmentation fault for unknown reason)
* Prepare arm64 tests to be run on a native arm64 runner (no qemu involved); tests are still disabled because of https://github.com/AppImageCrafters/appimage-builder/issues/272 and may be enabled as soon as a fixed release of appimage-builder is available.
* Update GitHub actions to the latest version

FYI: Native arm64 runners are now available for public projects, offering a significant performance boost. Unfortunately the AppImage build cannot use them because the [build-appimage](https://github.com/AppImageCrafters/build-appimage) action uses a docker image that is `amd64` only.

A [GitHub Action run](https://github.com/git-developer/sc-controller/actions/runs/18631694665) is available as demonstration.