### PR TITLE
Add option to run scc-daemon in foreground

### DIFF
--- a/scc/bin/scc_daemon.py
+++ b/scc/bin/scc_daemon.py
@@ -14,6 +14,7 @@ def main() -> None:
 	parser.add_argument("command", type=str, choices=["start", "stop", "restart", "debug"])
 	parser.add_argument("--alone", action="store_true", help="prevent scc-daemon from launching osd-daemon and autoswitch-daemon")
 	parser.add_argument("--once", action="store_true", help="use with 'stop' to send single SIGTERM without waiting for daemon to exit")
+	parser.add_argument("--foreground", action="store_true", help="run scc-daemon in foreground")
 	daemon = SCCDaemon(get_pid_file(), get_daemon_socket())
 	args = parser.parse_args()
 	daemon.alone = args.alone
@@ -25,7 +26,7 @@ def main() -> None:
 		# from config
 
 	if args.command == "start":
-		daemon.start()
+		daemon.start(foreground = args.foreground)
 	elif args.command == "stop":
 		daemon.stop(once = args.once)
 	elif args.command == "restart":

--- a/scc/lib/daemon.py
+++ b/scc/lib/daemon.py
@@ -73,7 +73,7 @@ class Daemon:
 		"""Delete pid file"""
 		os.remove(self.pidfile)
 
-	def start(self):
+	def start(self, foreground=False):
 		"""Start the daemon."""
 
 		# Check for a pidfile to see if the daemon already runs
@@ -103,7 +103,10 @@ class Daemon:
 			sys.stderr.write("Overwriting stale pidfile\n")
 
 		# Start the daemon
-		self.daemonize()
+		if not foreground:
+			self.daemonize()
+		else:
+			self.write_pid()
 		syslog.syslog(syslog.LOG_INFO, '{}: started'.format(os.path.basename(sys.argv[0])))
 		self.on_start()
 		while True:


### PR DESCRIPTION
Broad access to `/dev/uinput` is a security risk so I solved it by launching scc-daemon as a systemd service with access to `/dev/uinput` while GUI is launched by a regular user without special privileges. The problem is that `scc-daemon start` launches the daemon to background and it doesn't work well when launched as a systemd service. The partial solution is to use `scc-daemon debug` but this outputs verbose information to the log that is not necessary in regular use.

This PR adds opt-in `--foreground` flag that launches the daemon in foreground.