### PR TITLE
fix(appimage): make the AppImage run on minimal hosts (SteamOS/Deck)

### DIFF
--- a/AppImageBuilder.debian.yml
+++ b/AppImageBuilder.debian.yml
@@ -113,6 +113,10 @@ AppDir:
       - libbluetooth3
       - libgtk-3-0
       - libgtk-layer-shell-dev
+      - gir1.2-gtklayershell-0.1
+      - gir1.2-ayatanaappindicator3-0.1
+      - libdbusmenu-glib4
+      - libdbusmenu-gtk3-4
       - librsvg2-common
       - libwayland-client0
       - libwayland-cursor0
@@ -133,15 +137,18 @@ AppDir:
       - libgmp*         # arithmetics
 
       # gir1.2-rsvg-2.0
-      - libicu*         # i18n
+      # NOTE: libicu* and libxml* are intentionally NOT excluded. The bundled
+      # librsvg needs libxml2 (which pulls in icu), and minimal hosts such as
+      # SteamOS do not provide them, so excluding them gives a fatal
+      # "libxml2.so.2: cannot open shared object file" at GUI startup. Bundling
+      # them matches what the older appimage-build.sh shipped.
       - libstdc*        # development
-      - libxml*         # codec
 
       # libgtk3-0
       - "*-icon-theme"  # gui
       - "*crypt*"       # security
       - "*dconf*"       # gui configuration
-      - "*dbus*"        # process communication
+      - "libdbus-1*"    # process communication (keep libdbusmenu for the tray icon)
       - "*gcc*"         # development
       - "*systemd*"     # linux core
       - libblk*         # filesystem

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -106,6 +106,10 @@ AppDir:
       - libbluetooth3
       - libgtk-3-0
       - libgtk-layer-shell-dev
+      - gir1.2-gtklayershell-0.1
+      - gir1.2-ayatanaappindicator3-0.1
+      - libdbusmenu-glib4
+      - libdbusmenu-gtk3-4
       - librsvg2-common
       - libwayland-client0
       - libwayland-cursor0
@@ -126,15 +130,18 @@ AppDir:
       - libgmp*         # arithmetics
 
       # gir1.2-rsvg-2.0
-      - libicu*         # i18n
+      # NOTE: libicu* and libxml* are intentionally NOT excluded. The bundled
+      # librsvg needs libxml2 (which pulls in icu), and minimal hosts such as
+      # SteamOS do not provide them, so excluding them gives a fatal
+      # "libxml2.so.2: cannot open shared object file" at GUI startup. Bundling
+      # them matches what the older appimage-build.sh shipped.
       - libstdc*        # development
-      - libxml*         # codec
 
       # libgtk3-0
       - "*-icon-theme"  # gui
       - "*crypt*"       # security
       - "*dconf*"       # gui configuration
-      - "*dbus*"        # process communication
+      - "libdbus-1*"    # process communication (keep libdbusmenu for the tray icon)
       - "*gcc*"         # development
       - "*systemd*"     # linux core
       - libblk*         # filesystem


### PR DESCRIPTION
Split out of #100 as its own per-problem PR, per @C0rn3j's request in https://github.com/C0rn3j/sc-controller/issues/98#issuecomment-4844655764 (ship non-SC2 changes as separate PRs).

This fixes two independent failures of the AppImage on hosts that ship a minimal library set, such as SteamOS and the Steam Deck.

**Tray / status icon**
The Ayatana AppIndicator tray icon needs its runtime libraries bundled: `gir1.2-gtklayershell-0.1`, `gir1.2-ayatanaappindicator3-0.1`, `libdbusmenu-glib4`, `libdbusmenu-gtk3-4`. The `*dbus*` exclude is also narrowed to `libdbus-1*`, because the broad glob matched `libdbusmenu-*` too and stripped the tray libraries right back out of the bundle (cancelling the `include`), leaving the tray icon dead on hosts that don't provide them.

**librsvg / GUI startup**
librsvg needs libxml2 (which pulls in icu) at GUI startup. Excluding `libicu*` / `libxml*` gives a fatal `libxml2.so.2: cannot open shared object file` on hosts that don't provide them. They are no longer excluded.

Applied to both `AppImageBuilder.yml` and `AppImageBuilder.debian.yml`.
