### PR TITLE
fix(uinput): build enums via functional IntEnum API (fixes #24); require Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 	"Operating System :: POSIX :: Linux",
 	"Typing :: Typed",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 #platforms = ["Linux"]
 
 # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#creating-executable-scripts

--- a/scc/uinput.py
+++ b/scc/uinput.py
@@ -49,28 +49,23 @@ else:
 MAX_FEEDBACK_EFFECTS = 4
 
 
-class Keys(IntEnum):
-	"""Keys enum contains all keys and button from linux/uinput.h (KEY_* BTN_*)."""
+# Build these enums via the functional IntEnum(...) API, not a class body doing
+# `locals().update(...)`. The class-body form relies on dict.update() reaching
+# enum's _EnumDict.__setitem__, which it does NOT on Python <= 3.10: every member
+# is silently dropped and the enum imports EMPTY (KeyError: 'KEY_ESC' at import --
+# issue #24). requires-python is >=3.11, but the AppImages bundle their base
+# distro's Python (jammy = 3.10), so the robust construction is kept.
+Keys = IntEnum("Keys", {i: CHEAD[i] for i in CHEAD if i.startswith(("KEY_", "BTN_"))})
+Keys.__doc__ = "Keys enum contains all keys and buttons from linux/uinput.h (KEY_* BTN_*)."
 
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith(("KEY_", "BTN_"))})
+KeysOnly = IntEnum("KeysOnly", {i: CHEAD[i] for i in CHEAD if i.startswith("KEY_")})
+KeysOnly.__doc__ = "KeysOnly enum contains all keys from linux/uinput.h (KEY_*)."
 
+Axes = IntEnum("Axes", {i: CHEAD[i] for i in CHEAD if i.startswith("ABS_")})
+Axes.__doc__ = "Axes enum contains all axes from linux/uinput.h (ABS_*)."
 
-class KeysOnly(IntEnum):
-	"""Keys enum contains all keys and button from linux/uinput.h (KEY_* BTN_*)."""
-
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith("KEY_")})
-
-
-class Axes(IntEnum):
-	"""Axes enum contains all axes from linux/uinput.h (ABS_*)."""
-
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith("ABS_")})
-
-
-class Rels(IntEnum):
-	"""Rels enum contains all rels from linux/uinput.h (REL_*)."""
-
-	locals().update({i: CHEAD[i] for i in CHEAD if i.startswith("REL_")})
+Rels = IntEnum("Rels", {i: CHEAD[i] for i in CHEAD if i.startswith("REL_")})
+Rels.__doc__ = "Rels enum contains all rels from linux/uinput.h (REL_*)."
 
 
 # Scan codes for each keys (taken from a logitech keyboard)


### PR DESCRIPTION
Split out of #100 as its own per-problem PR, per @C0rn3j's request in https://github.com/C0rn3j/sc-controller/issues/98#issuecomment-4844655764 (ship non-SC2 changes as separate PRs).

**The bug (#24).** `Keys/KeysOnly/Axes/Rels` are built with a class body doing `locals().update({...})`, which relies on `dict.update()` reaching enum's `_EnumDict.__setitem__` — which it does **not** on Python ≤ 3.10. Every member is silently dropped, `scc.uinput` imports an EMPTY enum, and the daemon/GUI die at startup with `KeyError: 'KEY_ESC'`. That is #24 (bullseye, Python 3.9), and it also breaks any AppImage whose base ships Python 3.10, such as jammy. The functional `IntEnum(name, mapping)` API registers every member identically on all versions (verified on 3.10, 3.11, 3.12 and 3.14).

**The floor.** Separately, Python 3.10 is EOL in October 2026, so `requires-python` moves to `>=3.11` for source / pip installs. The functional enum is kept regardless (it is just robust code), so the bundled-Python AppImages that still ship 3.10 keep working.

Fixes #24.
