### PR TITLE
Fix scc-osd-message doing nothing when run as an entry point

### DIFF
--- a/scc/bin/scc_osd_message.py
+++ b/scc/bin/scc_osd_message.py
@@ -8,26 +8,25 @@ def main() -> None:
 		print("\n*break*")
 		sys.exit(0)
 
-	if __name__ == "__main__":
-		signal.signal(signal.SIGINT, sigint)
+	signal.signal(signal.SIGINT, sigint)
 
-		import gi
+	import gi
 
-		gi.require_version("Gtk", "3.0")
-		gi.require_version("Rsvg", "2.0")
-		gi.require_version("GdkX11", "3.0")
+	gi.require_version("Gtk", "3.0")
+	gi.require_version("Rsvg", "2.0")
+	gi.require_version("GdkX11", "3.0")
 
-		from scc.tools import init_logging
+	from scc.tools import init_logging
 
-		init_logging()
+	init_logging()
 
-		from scc.osd.message import Message
+	from scc.osd.message import Message
 
-		m = Message()
-		if not m.parse_argumets(sys.argv):
-			sys.exit(1)
-		m.run()
-		sys.exit(m.get_exit_code())
+	m = Message()
+	if not m.parse_argumets(sys.argv):
+		sys.exit(1)
+	m.run()
+	sys.exit(m.get_exit_code())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The main() function in scc/bin/scc_osd_message.py wraps its whole body in a guard which is skipped when the module is imported. Remove the inner guard so that the body always runs,, matching the other scc-osd-* tools. 

This is one of a few changes made in response to review from Debian.