### PR TITLE
fix: Add uaccess tag to the Valve and Sony USB udev rules

### DIFF
--- a/scripts/69-sc-controller.rules
+++ b/scripts/69-sc-controller.rules
@@ -3,11 +3,11 @@
 # MODE="0660", GROUP="games" to allow r/w access only to members of that group.
 
 # Valve USB devices
-SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0666", TAG+="uaccess"
 # Valve HID devices over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*28DE:*", MODE="0666", TAG+="uaccess"
 # Sony USB devices
-SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", MODE="0666", TAG+="uaccess"
 # Sony input devices over bluetooth
 SUBSYSTEM=="input", KERNELS=="*054C:09CC*", MODE="0666", TAG+="uaccess"
 SUBSYSTEM=="input", KERNELS=="*054C:0CE6*", MODE="0666", TAG+="uaccess"


### PR DESCRIPTION
The two SUBSYSTEM="usb" rules for Valve/28de and Sony/054c set MODE="0666" but do not set TAG+="uaccess". The bluetooth and hidraw rules in the same file already set it. Without it the device is not handed to the active local session through logind, so this adds the tag to both USB rules.