### PR TITLE
fix: Catch ValueError when importing AppIndicator

### DIFF
--- a/scc/gui/statusicon.py
+++ b/scc/gui/statusicon.py
@@ -245,7 +245,7 @@ class StatusIconAppIndicator(StatusIconDBus):
 			try:
 				gi.require_version("AyatanaAppIndicator3", "0.1")
 				from gi.repository import AyatanaAppIndicator3 as appindicator
-			except ImportError:
+			except ImportError, ValueError:
 				log.warning(
 					"Failed to import AyatanaAppIndicator3, trying fallback to an old implementation of AppIndicator3!",
 				)
@@ -254,7 +254,7 @@ class StatusIconAppIndicator(StatusIconDBus):
 
 			self._status_active = appindicator.IndicatorStatus.ACTIVE
 			self._status_passive = appindicator.IndicatorStatus.PASSIVE
-		except ImportError:
+		except ImportError, ValueError:
 			log.warning("Failed to import AppIndicator3")
 			raise NotImplementedError
 


### PR DESCRIPTION
`gi.require_version()` raises a `ValueError` if the requested package is missing:
```python
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/scc/gui/app.py", line 1351, in do_startup
    self.setup_statusicon()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/scc/gui/app.py", line 285, in setup_statusicon
    self.statusicon = get_status_icon(self.imagepath, menu)
                      ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/scc/gui/statusicon.py", line 410, in get_status_icon
    return StatusIconProxy(*args, **kwargs)
  File "/usr/lib/python3.14/site-packages/scc/gui/statusicon.py", line 310, in __init__
    self._load_fallback()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/scc/gui/statusicon.py", line 340, in _load_fallback
    self._status_fb = StatusIconBackend(*self._arguments[0], **self._arguments[1])
                      ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/scc/gui/statusicon.py", line 248, in __init__
    gi.require_version("AyatanaAppIndicator3", "0.1")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/gi/__init__.py", line 150, in require_version
    raise ValueError(f"Namespace {namespace} not available")
ValueError: Namespace AyatanaAppIndicator3 not available
```