### PR TITLE
fix: Implement destroy method for StatusIconDummy

### DIFF
--- a/scc/gui/statusicon.py
+++ b/scc/gui/statusicon.py
@@ -168,6 +168,9 @@ class StatusIconDummy(StatusIcon):
 		self._get_icon(icon)
 		self._get_text(text)
 
+	def destroy(self):
+		return
+
 
 class StatusIconGTK3(StatusIcon):
 	"""Gtk.StatusIcon based status icon backend"""


### PR DESCRIPTION
This is needed to avoid error when the user disables the tray icon in the settings:
```python
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/scc/gui/global_settings.py", line 387, in on_random_checkbox_toggled
    self.save_config()
    ~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/scc/gui/global_settings.py", line 309, in save_config
    self.app.destroy_statusicon()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/scc/gui/app.py", line 294, in destroy_statusicon
    self.statusicon.destroy()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/scc/gui/statusicon.py", line 380, in destroy
    self._status_fb.destroy()
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'StatusIconDummy' object has no attribute 'destroy'
```